### PR TITLE
Add [userdata] Arg

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,9 +12,19 @@ cli
   .option('-S, --sequence', 'display match sequence along with the results')
   .option('-s, --crack-times-sec', 'display crack time estimations in seconds')
   .option('--no-color', 'disable color support')
-  .arguments('<password>')
-  .action(function (password) {
+  .arguments('<password> [userdata]')
+  .action(function (password, userdata) {
     pwd = password;
+
+    if (! userdata) {
+      data = [];
+    } else {
+      try {
+        data = JSON.parse(userdata);
+      } catch (error) {
+        data = userdata.split(' ');
+      }
+    }
   });
 
 cli.on('--help', function () {
@@ -36,10 +46,10 @@ if (typeof pwd === 'undefined') {
 }
 
 var options = {
+  data: data,
   limitResults: cli.limitResults,
   sequence: cli.sequence,
   crackTimesSec: cli.crackTimesSec
 };
 
 sResults.output(pwd, options);
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,11 +32,10 @@ var htable = new Table(boxProp);
 module.exports = {
 
   output: function (pwd, options) {
-
     var limitResults = options.limitResults;
     var crackTimesSec = options.crackTimesSec;
     var sequence = options.sequence;
-    res = zxcvbn(pwd);
+    res = zxcvbn(pwd, options.data);
 
     if (limitResults) { console.log('\nPassword:\t' + res.password + '\n\nScore:\t\t[' + res.score + ' / 4]'); } else {
       console.log('\nPassword:\t' + res.password +

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var expect = require('chai').expect;
+require('mocha');
 require('mocha-sinon');
 var outputData = require('./lib/index');
 
@@ -18,6 +19,17 @@ describe('output()', function() {
     outputData.output('correcthorsebatterystaple', options);
     expect(console.log.calledOnce).to.be.false;
     expect(console.log.calledWith('\nPassword:\tcorrecthorsebatterystaple\n\nScore:\t\t[4 / 4]')).to.be.true;
+  });
+
+  it('should accept user data and penalize given words', function() {
+    // confirm password gets 4/4 without userdata
+    outputData.output('incorrecthorsebatteries', options);
+    expect(console.log.calledWith('\nPassword:\tincorrecthorsebatteries\n\nScore:\t\t[4 / 4]')).to.be.true;
+
+    // add userdata
+    options.data = ['incorrect', 'horse'];
+    outputData.output('incorrecthorsebatteries', options);
+    expect(console.log.calledWith('\nPassword:\tincorrecthorsebatteries\n\nScore:\t\t[3 / 4]')).to.be.true;
   });
 
 });


### PR DESCRIPTION
Allows userdata to be provided to zxcvbn as either json or space-separated words.

```bash
zxcvbn-cli$ # normally scores 4/4
zxcvbn-cli$ node cli.js incorrecthorsebatteries

Password:	incorrecthorsebatteries

Score:		[4 / 4]

Calc time:	5 ms

Guesses:	78846351310 (10.897)

Crack time estimations:

┌────────────────┬─────────────────────────────────────────────────────┐
│  Guesses       │  Time estimate                                      │
├────────────────┼─────────────────────────────────────────────────────┤
│  100 / hour    │  centuries (throttled online attack)                │
│  10  / second  │  centuries (unthrottled online attack)              │
│  10k / second  │  3 months (offline attack, slow hash, many cores)   │
│  10B / second  │  8 seconds (offline attack, fast hash, many cores)  │
└────────────────┴─────────────────────────────────────────────────────┘
```
```bash
zxcvbn-cli$ # adding userdata penalizes for known words; same password now scores 3/4
zxcvbn-cli$ # userdata can be passed as space-separated words
zxcvbn-cli$ node cli.js incorrecthorsebatteries incorrect horse

Password:	incorrecthorsebatteries

Score:		[3 / 4]

Calc time:	6 ms

Guesses:	146845000 (8.167)

Crack time estimations:

┌────────────────┬──────────────────────────────────────────────────────────────┐
│  Guesses       │  Time estimate                                               │
├────────────────┼──────────────────────────────────────────────────────────────┤
│  100 / hour    │  centuries (throttled online attack)                         │
│  10  / second  │  5 months (unthrottled online attack)                        │
│  10k / second  │  4 hours (offline attack, slow hash, many cores)             │
│  10B / second  │  less than a second (offline attack, fast hash, many cores)  │
└────────────────┴──────────────────────────────────────────────────────────────┘
```
```bash
zxcvbn-cli$ # userdata can be passed as a json-encoded array
zxcvbn-cli$ node cli.js incorrecthorsebatteries '["incorrect", "horse"]'

Password:	incorrecthorsebatteries

Score:		[3 / 4]

Calc time:	5 ms

Guesses:	146845000 (8.167)

Crack time estimations:

┌────────────────┬──────────────────────────────────────────────────────────────┐
│  Guesses       │  Time estimate                                               │
├────────────────┼──────────────────────────────────────────────────────────────┤
│  100 / hour    │  centuries (throttled online attack)                         │
│  10  / second  │  5 months (unthrottled online attack)                        │
│  10k / second  │  4 hours (offline attack, slow hash, many cores)             │
│  10B / second  │  less than a second (offline attack, fast hash, many cores)  │
└────────────────┴──────────────────────────────────────────────────────────────┘
```
```bash
zxcvbn-cli$ mocha test.js 

  output()

  2 passing (30ms)
```