### PR TITLE
Add --json Output Option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,6 +8,7 @@ var pkg = require('./package');
 cli
   .version(pkg.version)
   .description('A realistic password strength estimator.')
+  .option('-j, --json', 'json-encode zxcvbn results and output directly')
   .option('-l, --limit-results', 'display the password score, a warning (if any), and suggestions (if any)')
   .option('-S, --sequence', 'display match sequence along with the results')
   .option('-s, --crack-times-sec', 'display crack time estimations in seconds')
@@ -36,10 +37,10 @@ if (typeof pwd === 'undefined') {
 }
 
 var options = {
+  jsonOutput: cli.json,
   limitResults: cli.limitResults,
   sequence: cli.sequence,
   crackTimesSec: cli.crackTimesSec
 };
 
 sResults.output(pwd, options);
-

--- a/lib/index.js
+++ b/lib/index.js
@@ -38,6 +38,11 @@ module.exports = {
     var sequence = options.sequence;
     res = zxcvbn(pwd);
 
+    if (options.jsonOutput) {
+      console.log(JSON.stringify(res));
+      return;
+    }
+
     if (limitResults) { console.log('\nPassword:\t' + res.password + '\n\nScore:\t\t[' + res.score + ' / 4]'); } else {
       console.log('\nPassword:\t' + res.password +
                   '\n\nScore:\t\t' + '[' + res.score + ' / 4]' +

--- a/test.js
+++ b/test.js
@@ -2,22 +2,64 @@ var expect = require('chai').expect;
 require('mocha-sinon');
 var outputData = require('./lib/index');
 
-var options = {
-  limitResults: true,
-  crackTimesSec: false,
-  sequence: false
-};
+var options = {};
+var console_log = [];
 
 describe('output()', function() {
 
   beforeEach(function() {
-    this.sinon.stub(console, 'log');
+    // clear any previously logged console messages
+    console_log = [];
+    // stub console.log, we'll collect the messages instead
+    this.sinon.stub(console, 'log').callsFake(function () {
+      [].slice.call(arguments).forEach(function (output) {
+        console_log.push(output);
+      });
+    });
+
+    // reset options to default
+    options = {
+      jsonOutput: false,
+      limitResults: false,
+      crackTimesSec: false,
+      sequence: false
+    };
   });
 
-  it('should log "Password: correcthorsebatterystaple and Score: [4 / 4]" for that password input and -l option enabled', function() {
+  it('should log "Password: correcthorsebatterystaple" and "Score: [4 / 4]" for a strong password, with -l option enabled', function() {
+    var message;
+    options.limitResults = true;
     outputData.output('correcthorsebatterystaple', options);
+
     expect(console.log.calledOnce).to.be.false;
-    expect(console.log.calledWith('\nPassword:\tcorrecthorsebatterystaple\n\nScore:\t\t[4 / 4]')).to.be.true;
+
+    message = console_log.shift();
+    expect(message).to.match(/Password:.*correcthorsebatterystaple/m);
+    expect(message).to.match(/Score:.*[4 / 4]/m);
   });
 
+  it('should output raw results as a json-encoded object when -j option is enabled', function() {
+    var data;
+    options.jsonOutput = true;
+    outputData.output('correcthorsebatterystaple', options);
+
+    expect(console.log.calledOnce).to.be.true;
+
+    // test will also fail if JSON.parse errors
+    data = JSON.parse(console_log.shift());
+
+    expect(data).to.have.all.keys(
+      'password',
+      'guesses',
+      'guesses_log10',
+      'sequence',
+      'calc_time',
+      'crack_times_seconds',
+      'crack_times_display',
+      'score',
+      'feedback'
+    );
+
+    expect(data.score).to.equal(4);
+  });
 });


### PR DESCRIPTION
adds `-j|--json`, which returns the complete zxcvbn result as json.
also refactors test stubs for better usability.